### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/interfaceFactory.js
+++ b/lib/interfaceFactory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var Interface = function (params) {
     // Schema defines fields and can be used for validation and form generation (optional)

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "bugs": {
     "url": "https://github.com/jhsware/component-registry/issues"
   },
-  "repository" : { 
-      "type" : "git",
-      "url" : "git+https://github.com/jhsware/component-registry.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jhsware/component-registry.git"
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "node-uuid": "^1.4.3"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.